### PR TITLE
fix: The scenario where compatibility with "res" is {} (empty set)

### DIFF
--- a/packages/store.ts
+++ b/packages/store.ts
@@ -73,8 +73,9 @@ export class ChromeStorage<T extends Record<string, unknown>> {
     return new Promise((resolve) => {
       const reallyKey = this.scope ? this.scope : key;
       this.runTimeApi?.get?.(reallyKey as string | string[], (res) => {
+        // The scenario where compatibility with "res" is {} (empty set).
         const reallyRes = this.scope ? res[this.scope] : res;
-        const mergeDefaultRes = merge(this.defaultValue, reallyRes) as T;
+        const mergeDefaultRes = merge(this.defaultValue, reallyRes ?? {}) as T;
         if (Array.isArray(key)) resolve(pick<T, Key>(mergeDefaultRes, key));
         resolve(mergeDefaultRes[key as string] as T[Key]);
       });


### PR DESCRIPTION
fixed: handling response: TypeError: Cannot convert undefined or null to object
at Function.keys